### PR TITLE
fix: always use terser source maps to ensure proper file resolving

### DIFF
--- a/packages/varan/test/fixtures/webpack/customClient.js
+++ b/packages/varan/test/fixtures/webpack/customClient.js
@@ -76,7 +76,6 @@ module.exports = {
     new DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('production'),
     }),
-    new NoEmitOnErrorsPlugin(),
     new MiniCssExtractPlugin({
       filename: 'static/css/[name].[hash:8].css',
       chunkFilename: 'static/css/[name].[hash:8].chunk.css',
@@ -87,10 +86,11 @@ module.exports = {
     }),
   ],
   optimization: {
+    noEmitOnErrors: true,
     minimizer: [
       new TerserPlugin({
-        cache: true,
-        parallel: true,
+        cache: false,
+        parallel: false,
         terserOptions: {
           compress: true,
           output: {

--- a/packages/varan/webpack/client.js
+++ b/packages/varan/webpack/client.js
@@ -219,6 +219,7 @@ module.exports = options => {
                   ascii_only: true,
                 },
               },
+              sourceMap: true,
             }),
           ],
           splitChunks: {


### PR DESCRIPTION
fixes issues where source maps are disabled in webpack devtool and terser is unable to resolve files